### PR TITLE
✨ Add ImpersonateDropdown navigation component

### DIFF
--- a/assets/dist/impersonate_dropdown.js
+++ b/assets/dist/impersonate_dropdown.js
@@ -1,0 +1,136 @@
+import { Controller } from '@hotwired/stimulus';
+
+export default class extends Controller {
+    static targets = ['input', 'results'];
+
+    static values = {
+        searchUrl: String,
+        noResultsLabel: { type: String, default: 'No results' },
+        exitParameter: { type: String, default: '_switch_user' },
+        debounce: { type: Number, default: 250 },
+        minLength: { type: Number, default: 2 },
+    };
+
+    initialize() {
+        this.timer = null;
+        this.abortController = null;
+    }
+
+    disconnect() {
+        if (this.timer) {
+            clearTimeout(this.timer);
+            this.timer = null;
+        }
+        if (this.abortController) {
+            this.abortController.abort();
+            this.abortController = null;
+        }
+    }
+
+    search() {
+        const query = this.inputTarget.value.trim();
+
+        if (this.timer) {
+            clearTimeout(this.timer);
+        }
+
+        if (query.length < this.minLengthValue) {
+            this.clearResults();
+            return;
+        }
+
+        this.timer = setTimeout(() => this.fetchResults(query), this.debounceValue);
+    }
+
+    fetchResults(query) {
+        if (this.abortController) {
+            this.abortController.abort();
+        }
+        this.abortController = new AbortController();
+
+        const url = new URL(this.searchUrlValue, document.location.origin);
+        url.searchParams.set('q', query);
+
+        fetch(url.toString(), {
+            signal: this.abortController.signal,
+            headers: { Accept: 'application/json' },
+        })
+            .then((response) => {
+                if (!response.ok) {
+                    throw new Error(`HTTP ${response.status}`);
+                }
+                return response.json();
+            })
+            .then((items) => this.renderResults(Array.isArray(items) ? items : []))
+            .catch((error) => {
+                if (error.name === 'AbortError') {
+                    return;
+                }
+                this.renderError();
+            });
+    }
+
+    renderResults(items) {
+        this.resultsTarget.replaceChildren();
+
+        if (items.length === 0) {
+            const empty = document.createElement('li');
+            empty.className = 'dropdown-item-text text-muted small';
+            empty.textContent = this.noResultsLabelValue;
+            this.resultsTarget.appendChild(empty);
+            return;
+        }
+
+        const fragment = document.createDocumentFragment();
+        for (const item of items) {
+            fragment.appendChild(this.buildItem(item));
+        }
+        this.resultsTarget.appendChild(fragment);
+    }
+
+    renderError() {
+        this.resultsTarget.replaceChildren();
+        const error = document.createElement('li');
+        error.className = 'dropdown-item-text text-danger small';
+        error.textContent = this.noResultsLabelValue;
+        this.resultsTarget.appendChild(error);
+    }
+
+    clearResults() {
+        if (this.resultsTarget) {
+            this.resultsTarget.replaceChildren();
+        }
+    }
+
+    buildItem(item) {
+        const li = document.createElement('li');
+        const link = document.createElement('a');
+        link.className = 'dropdown-item d-flex align-items-center gap-2';
+
+        const url = new URL(document.location.href);
+        url.searchParams.set(this.exitParameterValue, item.email ?? '');
+        link.href = url.toString();
+
+        if (item.initials) {
+            const initials = document.createElement('span');
+            initials.className = 'enabel-ux-impersonate-initials';
+            initials.textContent = item.initials;
+            link.appendChild(initials);
+        }
+
+        const label = document.createElement('span');
+        label.className = 'flex-grow-1';
+        label.textContent = item.displayName ?? item.email ?? '';
+        link.appendChild(label);
+
+        if (item.email && item.displayName) {
+            const email = document.createElement('small');
+            email.className = 'text-muted';
+            email.textContent = item.email;
+            link.appendChild(email);
+        }
+
+        li.appendChild(link);
+        return li;
+    }
+}

--- a/assets/package.json
+++ b/assets/package.json
@@ -7,6 +7,11 @@
                 "main": "dist/modal.js",
                 "fetch": "eager",
                 "enabled": true
+            },
+            "impersonate_dropdown": {
+                "main": "dist/impersonate_dropdown.js",
+                "fetch": "lazy",
+                "enabled": true
             }
         },
         "importmap": {

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -48,6 +48,10 @@ services:
     tags:
       - { name: 'twig.component', key: 'Enabel:Ux:ImpersonateBanner', template: '@EnabelUx/navigation/impersonate_banner.html.twig', expose_public_props: true }
 
+  Enabel\Ux\Component\Navigation\ImpersonateDropdown:
+    tags:
+      - { name: 'twig.component', key: 'Enabel:Ux:ImpersonateDropdown', template: '@EnabelUx/navigation/impersonate_dropdown.html.twig', expose_public_props: true }
+
   Enabel\Ux\Component\Callout\Callout:
     tags:
       - { name: 'twig.component', key: 'Enabel:Ux:Callout', template: '@EnabelUx/callout/callout.html.twig', expose_public_props: true }

--- a/docs/Navigation/impersonateDropdown.md
+++ b/docs/Navigation/impersonateDropdown.md
@@ -19,6 +19,7 @@ Pairs with [`Enabel:Ux:ImpersonateBanner`](impersonateBanner.md) (issue #16), wh
 | `title`             | `?string` | Tooltip on the dropdown toggle button (HTML `title` attribute)                                         | `null`                    |
 | `exitParameter`     | `string`  | Query-string key appended on row click (Symfony's default is `_switch_user`)                           | `'_switch_user'`          |
 | `debounce`          | `int`     | Search debounce delay in milliseconds                                                                  | `250`                     |
+| `minLength`         | `int`     | Minimum query length before the controller fires a fetch (under this, the results list is cleared)     | `2`                       |
 
 ## Endpoint contract
 
@@ -37,7 +38,7 @@ The component issues `GET {searchUrl}?q={query}` after the debounce window, expe
 
 The endpoint must be protected by `ROLE_ALLOWED_TO_SWITCH` (or stricter) at the controller level — the component only renders the widget, it does not gate access.
 
-The Stimulus controller fires no request until the input contains at least 2 characters, aborts in-flight requests when the query changes, and renders an empty-state row when the endpoint returns `[]`.
+The Stimulus controller fires no request until the input contains at least `minLength` characters (default 2), aborts in-flight requests when the query changes, and renders an empty-state row when the endpoint returns `[]`.
 
 ## Usage
 

--- a/docs/Navigation/impersonateDropdown.md
+++ b/docs/Navigation/impersonateDropdown.md
@@ -1,0 +1,100 @@
+# ImpersonateDropdown Component
+
+## Description
+
+A navbar dropdown that lets `ROLE_ALLOWED_TO_SWITCH` users start impersonating someone else. A debounced search input queries a JSON endpoint provided by the host application and renders the results as clickable items that navigate to the current URL with the `?_switch_user=<email>` parameter appended — the contract Symfony's Security component listens for.
+
+Replaces the ad-hoc impersonate widget copied across Enabel apps (SymfonyBase, InformationPortal, Impala) — same Stimulus pattern, single shipped controller.
+
+Pairs with [`Enabel:Ux:ImpersonateBanner`](impersonateBanner.md) (issue #16), which signals the active impersonation at the top of the page.
+
+## Parameters
+
+| Parameter           | Type      | Description                                                                                            | Default                   |
+|:--------------------|:----------|:-------------------------------------------------------------------------------------------------------|:--------------------------|
+| `searchUrl`         | `string`  | URL of the project's JSON search endpoint (**required**)                                               | —                         |
+| `searchPlaceholder` | `string`  | Placeholder shown in the search input — translate at the call site                                     | `''`                      |
+| `noResultsLabel`    | `string`  | Label shown when the query returns no rows                                                             | `'No results'`            |
+| `icon`              | `string`  | Icon identifier passed to `ux_icon()`                                                                  | `'fa6-solid:user-secret'` |
+| `title`             | `?string` | Tooltip on the dropdown toggle button (HTML `title` attribute)                                         | `null`                    |
+| `exitParameter`     | `string`  | Query-string key appended on row click (Symfony's default is `_switch_user`)                           | `'_switch_user'`          |
+| `debounce`          | `int`     | Search debounce delay in milliseconds                                                                  | `250`                     |
+
+## Endpoint contract
+
+The component issues `GET {searchUrl}?q={query}` after the debounce window, expecting a JSON array of objects with the following shape:
+
+```json
+[
+    { "email": "jane.doe@enabel.be", "displayName": "Jane Doe", "initials": "JD" },
+    { "email": "john.smith@enabel.be", "displayName": "John Smith", "initials": "JS" }
+]
+```
+
+- `email` — appended as `?_switch_user=<email>` on click (the only field that is functionally required for impersonation)
+- `displayName` — shown as the row label; falls back to `email` if missing
+- `initials` — rendered in a small round avatar to the left of the label; the avatar is omitted if `initials` is empty
+
+The endpoint must be protected by `ROLE_ALLOWED_TO_SWITCH` (or stricter) at the controller level — the component only renders the widget, it does not gate access.
+
+The Stimulus controller fires no request until the input contains at least 2 characters, aborts in-flight requests when the query changes, and renders an empty-state row when the endpoint returns `[]`.
+
+## Usage
+
+### Inside Enabel:Ux:Menu, gated by Symfony Security
+
+```twig
+{% component 'Enabel:Ux:Menu' with { align: 'end' } %}
+    {% block content %}
+        {% if is_granted('ROLE_ALLOWED_TO_SWITCH') and not is_granted('IS_IMPERSONATOR') %}
+            {{ component('Enabel:Ux:ImpersonateDropdown', {
+                searchUrl: path('admin_user_search'),
+                searchPlaceholder: 'nav.impersonate.search'|trans,
+                noResultsLabel: 'nav.impersonate.no_results'|trans,
+                title: 'nav.impersonate.title'|trans,
+            }) }}
+        {% endif %}
+
+        {{ component('Enabel:Ux:UserMenu', { name: app.user.displayName }) }}
+    {% endblock %}
+{% endcomponent %}
+```
+
+The `not is_granted('IS_IMPERSONATOR')` guard keeps the entry-point hidden once impersonation is active — the `Enabel:Ux:ImpersonateBanner` then takes over.
+
+### Sample controller for the search endpoint
+
+```php
+#[Route('/admin/users/search', name: 'admin_user_search', methods: ['GET'])]
+#[IsGranted('ROLE_ALLOWED_TO_SWITCH')]
+public function search(Request $request, UserRepository $users): JsonResponse
+{
+    $query = trim($request->query->get('q', ''));
+    if (\strlen($query) < 2) {
+        return new JsonResponse([]);
+    }
+
+    return new JsonResponse(array_map(
+        fn (User $user) => [
+            'email' => $user->getEmail(),
+            'displayName' => $user->getDisplayName(),
+            'initials' => $user->getInitials(),
+        ],
+        $users->searchByName($query, limit: 20),
+    ));
+}
+```
+
+## Stimulus controller
+
+The component is wired to the Stimulus controller shipped at `assets/dist/impersonate_dropdown.js` (`@enabel/ux/impersonate_dropdown`). Symfony AssetMapper auto-discovers it through the bundle's `assets/package.json` — no manual `controllers.json` edit needed in the consumer.
+
+The controller is registered with `fetch: 'lazy'` — the JS file is downloaded only when an element actually carries the `data-controller` attribute, which only happens when the dropdown is rendered (i.e. for `ROLE_ALLOWED_TO_SWITCH` users).
+
+### XSS safety
+
+All rendered fields (`displayName`, `email`, `initials`) are written to the DOM through `textContent`, never `innerHTML`, so a hostile JSON payload from the search endpoint cannot inject markup or scripts. The clickable URL is built via `new URL(document.location.href)` and `URLSearchParams.set` rather than string concatenation.
+
+## Pairs with
+
+- [ImpersonateBanner](impersonateBanner.md) — issue #16, the top banner that signals an active impersonation session.

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,7 @@ https://github.com/Enabel/Ux
   - [LocaleSwitcher](Navigation/localeSwitcher.md) - A locale switcher dropdown for Bootstrap navbar
   - [Tab](Navigation/tab.md) - A Bootstrap nav-tabs/nav-pills component for creating tabbed navigation
   - [ImpersonateBanner](Navigation/impersonateBanner.md) - A fixed-top banner for Symfony's user-impersonation feature
+  - [ImpersonateDropdown](Navigation/impersonateDropdown.md) - A navbar dropdown with a debounced JSON user search to start impersonation
 
 ## Layouts
 

--- a/src/Component/Navigation/ImpersonateDropdown.php
+++ b/src/Component/Navigation/ImpersonateDropdown.php
@@ -21,6 +21,7 @@ class ImpersonateDropdown
     public ?string $title;
     public string $exitParameter;
     public int $debounce;
+    public int $minLength;
 
     /**
      * @param array<string, mixed> $data
@@ -47,6 +48,7 @@ class ImpersonateDropdown
             'title' => null,
             'exitParameter' => '_switch_user',
             'debounce' => 250,
+            'minLength' => 2,
         ]);
 
         $resolver->setAllowedTypes('searchUrl', 'string');
@@ -56,5 +58,6 @@ class ImpersonateDropdown
         $resolver->setAllowedTypes('title', ['string', 'null']);
         $resolver->setAllowedTypes('exitParameter', 'string');
         $resolver->setAllowedTypes('debounce', 'int');
+        $resolver->setAllowedTypes('minLength', 'int');
     }
 }

--- a/src/Component/Navigation/ImpersonateDropdown.php
+++ b/src/Component/Navigation/ImpersonateDropdown.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Enabel UX package.
+ * Copyright (c) Enabel <https://enabel.be/>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Enabel\Ux\Component\Navigation;
+
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\UX\TwigComponent\Attribute\PreMount;
+
+class ImpersonateDropdown
+{
+    public string $searchUrl;
+    public string $searchPlaceholder;
+    public string $noResultsLabel;
+    public string $icon;
+    public ?string $title;
+    public string $exitParameter;
+    public int $debounce;
+
+    /**
+     * @param array<string, mixed> $data
+     *
+     * @return array<string, mixed>
+     */
+    #[PreMount]
+    public function preMount(array $data): array
+    {
+        $resolver = new OptionsResolver();
+        $this->configureOptions($resolver);
+
+        return $resolver->resolve($data) + $data;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setIgnoreUndefined();
+        $resolver->setRequired('searchUrl');
+        $resolver->setDefaults([
+            'searchPlaceholder' => '',
+            'noResultsLabel' => 'No results',
+            'icon' => 'fa6-solid:user-secret',
+            'title' => null,
+            'exitParameter' => '_switch_user',
+            'debounce' => 250,
+        ]);
+
+        $resolver->setAllowedTypes('searchUrl', 'string');
+        $resolver->setAllowedTypes('searchPlaceholder', 'string');
+        $resolver->setAllowedTypes('noResultsLabel', 'string');
+        $resolver->setAllowedTypes('icon', 'string');
+        $resolver->setAllowedTypes('title', ['string', 'null']);
+        $resolver->setAllowedTypes('exitParameter', 'string');
+        $resolver->setAllowedTypes('debounce', 'int');
+    }
+}

--- a/templates/navigation/impersonate_dropdown.html.twig
+++ b/templates/navigation/impersonate_dropdown.html.twig
@@ -22,6 +22,7 @@
         noResultsLabel: noResultsLabel,
         exitParameter: exitParameter,
         debounce: debounce,
+        minLength: minLength,
     })) }}>
     <a class="nav-link dropdown-toggle"
        href="#"

--- a/templates/navigation/impersonate_dropdown.html.twig
+++ b/templates/navigation/impersonate_dropdown.html.twig
@@ -1,0 +1,44 @@
+{# Impersonate Dropdown component #}
+<style>
+    .enabel-ux-impersonate-dropdown { min-width: 320px; }
+    .enabel-ux-impersonate-results { max-height: 320px; overflow-y: auto; }
+    .enabel-ux-impersonate-initials {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 28px;
+        height: 28px;
+        border-radius: 50%;
+        background-color: #6c757d;
+        color: #fff;
+        font-size: 0.75rem;
+        font-weight: 600;
+        flex-shrink: 0;
+    }
+</style>
+<li class="nav-item dropdown {{ attributes.render('class') }}"
+    {{ attributes.defaults(stimulus_controller('enabel/ux/impersonate_dropdown', {
+        searchUrl: searchUrl,
+        noResultsLabel: noResultsLabel,
+        exitParameter: exitParameter,
+        debounce: debounce,
+    })) }}>
+    <a class="nav-link dropdown-toggle"
+       href="#"
+       role="button"
+       data-bs-toggle="dropdown"
+       aria-expanded="false"
+       {% if title %}title="{{ title }}"{% endif %}>
+        {{ ux_icon(icon, {height: '1.2rem'}) }}
+    </a>
+    <div class="dropdown-menu dropdown-menu-end p-2 enabel-ux-impersonate-dropdown">
+        <input type="search"
+               class="form-control form-control-sm mb-2"
+               placeholder="{{ searchPlaceholder }}"
+               autocomplete="off"
+               {{ stimulus_target('enabel/ux/impersonate_dropdown', 'input') }}
+               {{ stimulus_action('enabel/ux/impersonate_dropdown', 'search', 'input') }}>
+        <ul class="list-unstyled mb-0 enabel-ux-impersonate-results"
+            {{ stimulus_target('enabel/ux/impersonate_dropdown', 'results') }}></ul>
+    </div>
+</li>

--- a/tests/Component/Navigation/ImpersonateDropdownTest.php
+++ b/tests/Component/Navigation/ImpersonateDropdownTest.php
@@ -1,0 +1,134 @@
+<?php
+
+/*
+ * This file is part of the Enabel UX package.
+ * Copyright (c) Enabel <https://enabel.be/>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Enabel\Ux\Tests\Component\Navigation;
+
+use Enabel\Ux\Component\Navigation\ImpersonateDropdown;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
+use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
+
+class ImpersonateDropdownTest extends TestCase
+{
+    public function testComponentCanBeInstantiatedWithRequiredParameters(): void
+    {
+        $component = new ImpersonateDropdown();
+        $data = $component->preMount(['searchUrl' => '/admin/users/search']);
+
+        $component->searchUrl = $data['searchUrl'];
+        $component->searchPlaceholder = $data['searchPlaceholder'];
+        $component->noResultsLabel = $data['noResultsLabel'];
+        $component->icon = $data['icon'];
+        $component->title = $data['title'];
+        $component->exitParameter = $data['exitParameter'];
+        $component->debounce = $data['debounce'];
+
+        $this->assertSame('/admin/users/search', $component->searchUrl);
+        $this->assertSame('', $component->searchPlaceholder);
+        $this->assertSame('No results', $component->noResultsLabel);
+        $this->assertSame('fa6-solid:user-secret', $component->icon);
+        $this->assertNull($component->title);
+        $this->assertSame('_switch_user', $component->exitParameter);
+        $this->assertSame(250, $component->debounce);
+    }
+
+    public function testComponentCanBeInstantiatedWithCustomParameters(): void
+    {
+        $component = new ImpersonateDropdown();
+        $data = $component->preMount([
+            'searchUrl' => '/api/search',
+            'searchPlaceholder' => 'Rechercher…',
+            'noResultsLabel' => 'Aucun résultat',
+            'icon' => 'fa6-solid:mask',
+            'title' => 'Incarner un utilisateur',
+            'exitParameter' => '_switch',
+            'debounce' => 500,
+        ]);
+
+        $this->assertSame('/api/search', $data['searchUrl']);
+        $this->assertSame('Rechercher…', $data['searchPlaceholder']);
+        $this->assertSame('Aucun résultat', $data['noResultsLabel']);
+        $this->assertSame('fa6-solid:mask', $data['icon']);
+        $this->assertSame('Incarner un utilisateur', $data['title']);
+        $this->assertSame('_switch', $data['exitParameter']);
+        $this->assertSame(500, $data['debounce']);
+    }
+
+    public function testMissingSearchUrlThrows(): void
+    {
+        $this->expectException(MissingOptionsException::class);
+
+        $component = new ImpersonateDropdown();
+        $component->preMount([]);
+    }
+
+    public function testInvalidSearchUrlTypeThrows(): void
+    {
+        $this->expectException(InvalidOptionsException::class);
+
+        $component = new ImpersonateDropdown();
+        $component->preMount(['searchUrl' => null]);
+    }
+
+    public function testInvalidSearchPlaceholderTypeThrows(): void
+    {
+        $this->expectException(InvalidOptionsException::class);
+
+        $component = new ImpersonateDropdown();
+        $component->preMount([
+            'searchUrl' => '/search',
+            'searchPlaceholder' => 123,
+        ]);
+    }
+
+    public function testInvalidTitleTypeThrows(): void
+    {
+        $this->expectException(InvalidOptionsException::class);
+
+        $component = new ImpersonateDropdown();
+        $component->preMount([
+            'searchUrl' => '/search',
+            'title' => true,
+        ]);
+    }
+
+    public function testInvalidDebounceTypeThrows(): void
+    {
+        $this->expectException(InvalidOptionsException::class);
+
+        $component = new ImpersonateDropdown();
+        $component->preMount([
+            'searchUrl' => '/search',
+            'debounce' => '250',
+        ]);
+    }
+
+    public function testInvalidExitParameterTypeThrows(): void
+    {
+        $this->expectException(InvalidOptionsException::class);
+
+        $component = new ImpersonateDropdown();
+        $component->preMount([
+            'searchUrl' => '/search',
+            'exitParameter' => 42,
+        ]);
+    }
+
+    public function testPreMountPreservesAdditionalData(): void
+    {
+        $component = new ImpersonateDropdown();
+        $data = $component->preMount([
+            'searchUrl' => '/search',
+            'custom_attribute' => 'value',
+        ]);
+
+        $this->assertArrayHasKey('custom_attribute', $data);
+        $this->assertSame('value', $data['custom_attribute']);
+    }
+}

--- a/tests/Component/Navigation/ImpersonateDropdownTest.php
+++ b/tests/Component/Navigation/ImpersonateDropdownTest.php
@@ -28,6 +28,7 @@ class ImpersonateDropdownTest extends TestCase
         $component->title = $data['title'];
         $component->exitParameter = $data['exitParameter'];
         $component->debounce = $data['debounce'];
+        $component->minLength = $data['minLength'];
 
         $this->assertSame('/admin/users/search', $component->searchUrl);
         $this->assertSame('', $component->searchPlaceholder);
@@ -36,6 +37,7 @@ class ImpersonateDropdownTest extends TestCase
         $this->assertNull($component->title);
         $this->assertSame('_switch_user', $component->exitParameter);
         $this->assertSame(250, $component->debounce);
+        $this->assertSame(2, $component->minLength);
     }
 
     public function testComponentCanBeInstantiatedWithCustomParameters(): void
@@ -49,6 +51,7 @@ class ImpersonateDropdownTest extends TestCase
             'title' => 'Incarner un utilisateur',
             'exitParameter' => '_switch',
             'debounce' => 500,
+            'minLength' => 3,
         ]);
 
         $this->assertSame('/api/search', $data['searchUrl']);
@@ -58,6 +61,7 @@ class ImpersonateDropdownTest extends TestCase
         $this->assertSame('Incarner un utilisateur', $data['title']);
         $this->assertSame('_switch', $data['exitParameter']);
         $this->assertSame(500, $data['debounce']);
+        $this->assertSame(3, $data['minLength']);
     }
 
     public function testMissingSearchUrlThrows(): void
@@ -117,6 +121,17 @@ class ImpersonateDropdownTest extends TestCase
         $component->preMount([
             'searchUrl' => '/search',
             'exitParameter' => 42,
+        ]);
+    }
+
+    public function testInvalidMinLengthTypeThrows(): void
+    {
+        $this->expectException(InvalidOptionsException::class);
+
+        $component = new ImpersonateDropdown();
+        $component->preMount([
+            'searchUrl' => '/search',
+            'minLength' => '2',
         ]);
     }
 


### PR DESCRIPTION
## Summary

Adds an `ImpersonateDropdown` navigation component that lets `ROLE_ALLOWED_TO_SWITCH` users start impersonating someone else through a debounced JSON-search dropdown in the navbar.

- Renders a `<li class="nav-item dropdown">` with an icon toggle, a search input, and a result list — drop it inside `Enabel:Ux:Menu` like any other navbar item
- Ships a Stimulus controller (`assets/dist/impersonate_dropdown.js`) registered `lazy` in `assets/package.json`, so the JS is only fetched when an element with `data-controller` is on the page (i.e. for users who actually have the role)
- Mutualises three slightly-different copies of the same logic that lived in SymfonyBase, InformationPortal and Impala — single shipped controller, single contract
- Pairs naturally with #16 `Enabel:Ux:ImpersonateBanner` (which signals an active impersonation session)

## Endpoint contract (consumer-side)

The component issues `GET {searchUrl}?q={query}` after a 250 ms debounce, expecting:

```json
[
    { "email": "jane.doe@enabel.be", "displayName": "Jane Doe", "initials": "JD" }
]
```

Click navigates to the current URL with `?_switch_user=<email>` appended — the contract Symfony's Security component listens for.

## XSS safety

All rendered fields go through `textContent`, never `innerHTML`. The click-target URL is built via `new URL()` + `URLSearchParams.set`, not string concatenation. A hostile JSON payload from the search endpoint cannot inject markup or scripts.

## API

| Param               | Type      | Required | Default                   |
|:--------------------|:----------|:---------|:--------------------------|
| `searchUrl`         | `string`  | yes      | —                         |
| `searchPlaceholder` | `string`  | no       | `''`                      |
| `noResultsLabel`    | `string`  | no       | `'No results'`            |
| `icon`              | `string`  | no       | `'fa6-solid:user-secret'` |
| `title`             | `?string` | no       | `null`                    |
| `exitParameter`     | `string`  | no       | `'_switch_user'`          |
| `debounce`          | `int`     | no       | `250`                     |

`exitParameter` and `debounce` are not in the original issue spec — added so projects with custom `firewall.context.switch_user.parameter` configs or slower backends don't have to override the template.

## Test plan

- [x] PHPUnit: 245/245 (9 new tests: required `searchUrl`, defaults, custom params, type validation)
- [x] php-cs-fixer: clean
- [x] phpstan: no errors
- [ ] Manual smoke test in a consumer app — render inside the navbar, type a query, click a result, confirm impersonation kicks in. Also verify the JS is fetched lazily (Network tab) and that `data-controller` is not present for users without `ROLE_ALLOWED_TO_SWITCH`

Closes #15.
