### PR TITLE
✨ Add Symfony UX 3.x compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
         "php": ">=8.3",
         "symfony/http-foundation": "^7.3.7|^8.0",
         "symfony/options-resolver": "^7.3|^8.0",
-        "symfony/ux-icons": "^2.30",
-        "symfony/ux-twig-component": "^2.30",
+        "symfony/ux-icons": "^2.30|^3.0",
+        "symfony/ux-twig-component": "^2.30|^3.0",
         "twig/intl-extra": "^3.0",
         "twig/twig": "^3.0"
     },

--- a/templates/alert/alert.html.twig
+++ b/templates/alert/alert.html.twig
@@ -1,24 +1,11 @@
 {# Flash message component #}
-{% set typeCva = cva({
-    base: 'alert',
-    variants: {
-        type: {
-            primary: ' alert-primary',
-            secondary: ' alert-secondary',
-            success: ' alert-success',
-            danger: ' alert-danger',
-            warning: ' alert-warning',
-            info: ' alert-info',
-            light: ' alert-light',
-            dark: ' alert-dark',
-        },
-        dismissible: {
-            true: ' alert-dismissible fade show',
-        }
-    }
-}) %}
+{% set alertClasses = ['alert', 'alert-' ~ type] %}
+{% if dismissible %}
+    {% set alertClasses = alertClasses|merge(['alert-dismissible', 'fade', 'show']) %}
+{% endif %}
+{% set alertClass = alertClasses|join(' ') ~ (attributes.render('class') ? ' ' ~ attributes.render('class') : '') %}
 
-<div class="{{ typeCva.apply({type, dismissible}, attributes.render('class')) }}" {{ attributes.defaults({}) }} role="alert">
+<div class="{{ alertClass }}" {{ attributes.defaults({}) }} role="alert">
     {% block content %}
         {{ text|raw }}
     {% endblock %}

--- a/templates/callout/callout.html.twig
+++ b/templates/callout/callout.html.twig
@@ -1,31 +1,9 @@
 {# Callout component following Enabel Bootstrap Theme pattern #}
-{% if cva is defined %}
-    {% set typeCva = cva({
-        base: 'callout',
-        variants: {
-            type: {
-                primary: ' callout-primary',
-                secondary: ' callout-secondary',
-                success: ' callout-success',
-                danger: ' callout-danger',
-                warning: ' callout-warning',
-                info: ' callout-info',
-                light: ' callout-light',
-                dark: ' callout-dark',
-            },
-            size: {
-                sm: ' callout-sm',
-            }
-        }
-    }) %}
-    {% set calloutClass = typeCva.apply({type, size}, attributes.render('class')) %}
-{% else %}
-    {% set calloutClasses = ['callout', 'callout-' ~ type] %}
-    {% if size %}
-        {% set calloutClasses = calloutClasses|merge(['callout-' ~ size]) %}
-    {% endif %}
-    {% set calloutClass = calloutClasses|join(' ') ~ (attributes.render('class') ? ' ' ~ attributes.render('class') : '') %}
+{% set calloutClasses = ['callout', 'callout-' ~ type] %}
+{% if size %}
+    {% set calloutClasses = calloutClasses|merge(['callout-' ~ size]) %}
 {% endif %}
+{% set calloutClass = calloutClasses|join(' ') ~ (attributes.render('class') ? ' ' ~ attributes.render('class') : '') %}
 
 <div class="{{ calloutClass }}" {{ attributes.defaults({}) }}>
     {% if title or icon %}

--- a/templates/widget/widget.html.twig
+++ b/templates/widget/widget.html.twig
@@ -1,25 +1,6 @@
 {# Widget component following Enabel Bootstrap Theme pattern #}
-{% if cva is defined %}
-    {% set typeCva = cva({
-        base: 'widget',
-        variants: {
-            variant: {
-                primary: ' widget-primary',
-                secondary: ' widget-secondary',
-                success: ' widget-success',
-                danger: ' widget-danger',
-                warning: ' widget-warning',
-                info: ' widget-info',
-                light: ' widget-light',
-                dark: ' widget-dark',
-            }
-        }
-    }) %}
-    {% set widgetClass = typeCva.apply({variant}, attributes.render('class')) %}
-{% else %}
-    {% set widgetClasses = ['widget', 'widget-' ~ variant] %}
-    {% set widgetClass = widgetClasses|join(' ') ~ (attributes.render('class') ? ' ' ~ attributes.render('class') : '') %}
-{% endif %}
+{% set widgetClasses = ['widget', 'widget-' ~ variant] %}
+{% set widgetClass = widgetClasses|join(' ') ~ (attributes.render('class') ? ' ' ~ attributes.render('class') : '') %}
 
 {% if link %}
 <a href="{{ link }}" class="widget-link">

--- a/tools/phpstan/composer.json
+++ b/tools/phpstan/composer.json
@@ -1,5 +1,5 @@
 {
   "require": {
-    "phpstan/phpstan": "^1"
+    "phpstan/phpstan": "^2"
   }
 }


### PR DESCRIPTION
## What

- Widen `symfony/ux-icons` and `symfony/ux-twig-component` constraints to `^2.30|^3.0`
- Replace the `cva` Twig function (removed in TwigComponent 3.0) with plain class string building in `alert`, `widget` and `callout` templates
- Bump PHPStan to 2.x (1.12 cannot parse symfony/http-foundation 8.1 sources)

## Why not `html_cva`?

The upgrade guide suggests `html_cva` from `twig/html-extra`, but our usage is a trivial static type-to-class mapping. Manual concatenation avoids a new dependency and the extension registration requirement (`twig/extra-bundle`) in consuming apps. The `cva` branches in `widget`/`callout` were dead code anyway (`cva is defined` tests a variable, not the function), so the manual fallback already ran everywhere. Rendered HTML is unchanged.

## Notes for consumers

- No breaking change: PHP >= 8.3 and UX 2.30+ still supported
- Apps upgrading to UX 3.x must define `twig_component.defaults` (mandatory in 3.0) and need PHP >= 8.4 / Symfony >= 7.4

## Checks

- 246 tests, 672 assertions OK
- PHPStan level 8: no errors (against symfony 8.1 / ux 3.1)
- php-cs-fixer: nothing to fix