### PR TITLE
⬆️ Upgrade PHPUnit to 12 & test Symfony 7.4/8.1 in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,3 +17,37 @@ jobs:
   
   static-analysis:
     uses: Enabel/CI/.github/workflows/phpstan.yaml@main
+
+  symfony-versions:
+    name: Symfony ${{ matrix.symfony }} (PHP ${{ matrix.php }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - php: '8.3'
+            symfony: '7.4.*'
+          - php: '8.4'
+            symfony: '8.1.*'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+
+      - name: Install symfony/flex
+        run: |
+          composer global config --no-plugins allow-plugins.symfony/flex true
+          composer global require --no-progress --no-scripts symfony/flex
+
+      - name: Install dependencies (Symfony ${{ matrix.symfony }})
+        env:
+          SYMFONY_REQUIRE: ${{ matrix.symfony }}
+        run: composer update --prefer-dist --prefer-stable --no-progress
+
+      - name: Run tests
+        run: vendor/bin/phpunit

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,9 +6,41 @@ on:
     branches: ['main']
 
 jobs:
-  test:
-    uses: Enabel/CI/.github/workflows/phpunit.yaml@main
-  
+  tests:
+    name: PHP ${{ matrix.php }} (${{ matrix.name }} deps)
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - php: '8.3'
+            name: highest
+            flags: '--prefer-stable'
+          - php: '8.4'
+            name: highest
+            flags: '--prefer-stable'
+          - php: '8.3'
+            name: lowest
+            flags: '--prefer-lowest --prefer-stable'
+          - php: '8.4'
+            name: dev
+            flags: ''
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+
+      - name: Install dependencies
+        run: composer update ${{ matrix.flags }} --prefer-dist --no-progress
+
+      - name: Run tests
+        run: vendor/bin/phpunit
+
   composer-validate:
     uses: Enabel/CI/.github/workflows/composer-validate.yaml@main
   

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,13 +42,61 @@ jobs:
         run: vendor/bin/phpunit
 
   composer-validate:
-    uses: Enabel/CI/.github/workflows/composer-validate.yaml@main
-  
+    name: Validate composer.json
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          coverage: none
+
+      - name: Validate
+        run: composer validate --strict
+
   coding-standards:
-    uses: Enabel/CI/.github/workflows/php-cs-fixer.yaml@main
-  
+    name: PHP CS Fixer
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: none
+
+      - name: Install PHP CS Fixer
+        run: composer install --no-progress --prefer-dist --working-dir=tools/php-cs-fixer
+
+      - name: Run PHP CS Fixer
+        run: tools/php-cs-fixer/vendor/bin/php-cs-fixer fix --dry-run --diff
+
   static-analysis:
-    uses: Enabel/CI/.github/workflows/phpstan.yaml@main
+    name: PHPStan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --no-progress --prefer-dist --optimize-autoloader
+
+      - name: Install PHPStan
+        run: composer install --no-progress --prefer-dist --working-dir=tools/phpstan
+
+      - name: Run PHPStan
+        run: tools/phpstan/vendor/bin/phpstan analyse --memory-limit=1G
 
   symfony-versions:
     name: Symfony ${{ matrix.symfony }} (PHP ${{ matrix.php }})

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
             flags: ''
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -63,7 +63,7 @@ jobs:
             symfony: '8.1.*'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /vendor/
 composer.lock
 .php-cs-fixer.cache
+.phpunit.cache/
 .phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -18,18 +18,18 @@
     ],
     "require": {
         "php": ">=8.3",
-        "symfony/http-foundation": "^7.3.7|^8.0",
-        "symfony/options-resolver": "^7.3|^8.0",
-        "symfony/ux-icons": "^2.30|^3.0",
-        "symfony/ux-twig-component": "^2.30|^3.0",
+        "symfony/http-foundation": "^7.3.7 || ^8.0",
+        "symfony/options-resolver": "^7.3 || ^8.0",
+        "symfony/ux-icons": "^2.30 || ^3.0",
+        "symfony/ux-twig-component": "^2.30 || ^3.0",
         "twig/intl-extra": "^3.0",
         "twig/twig": "^3.0"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.48",
-        "phpunit/phpunit": "^9.6",
-        "symfony/framework-bundle": "^7.3|^8.0",
-        "symfony/phpunit-bridge": "^7.3|^8.0"
+        "phpunit/phpunit": "^12.0",
+        "symfony/framework-bundle": "^7.3 || ^8.0",
+        "symfony/phpunit-bridge": "^7.3 || ^8.0"
     },
     "suggest": {
         "symfony/asset-mapper": "Allows to manage frontend assets more easily."

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- https://phpunit.readthedocs.io/en/latest/configuration.html -->
+<!-- https://docs.phpunit.de/en/12.5/configuration.html -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
-         convertDeprecationsToExceptions="false"
+         cacheDirectory=".phpunit.cache"
+         displayDetailsOnPhpunitDeprecations="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
 >
     <php>
         <ini name="display_errors" value="1" />
         <ini name="error_reporting" value="-1" />
         <server name="APP_ENV" value="test" force="true" />
         <server name="SHELL_VERBOSITY" value="-1" />
-        <server name="SYMFONY_PHPUNIT_REMOVE" value="" />
-        <server name="SYMFONY_PHPUNIT_VERSION" value="9.6" />
     </php>
 
     <testsuites>
@@ -23,13 +23,13 @@
         </testsuite>
     </testsuites>
 
-    <coverage processUncoveredFiles="true">
+    <source>
         <include>
             <directory suffix=".php">src</directory>
         </include>
-    </coverage>
+    </source>
 
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
-    </listeners>
+    <extensions>
+        <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension" />
+    </extensions>
 </phpunit>

--- a/tests/Helper/ModalTest.php
+++ b/tests/Helper/ModalTest.php
@@ -27,8 +27,9 @@ class ModalTest extends TestCase
     protected function setUp(): void
     {
         $this->requestStack = new RequestStack();
-        $this->httpKernel = $this->createMock(HttpKernelInterface::class);
-        $this->twig = $this->createMock(Environment::class);
+        // Stubs: ces dépendances ne sont pas sollicitées par les scénarios redirect/callback.
+        $this->httpKernel = $this->createStub(HttpKernelInterface::class);
+        $this->twig = $this->createStub(Environment::class);
     }
 
     public function testRenderWithModalQueryParameter(): void
@@ -36,12 +37,13 @@ class ModalTest extends TestCase
         $request = new Request(['_enabel_ux_modal' => '1']);
         $this->requestStack->push($request);
 
-        $this->twig->expects($this->once())
+        $twig = $this->createMock(Environment::class);
+        $twig->expects($this->once())
             ->method('render')
             ->with('modal.html.twig', ['key' => 'value'])
             ->willReturn('<div>Modal Content</div>');
 
-        $modal = new Modal($this->requestStack, $this->httpKernel, $this->twig);
+        $modal = new Modal($this->requestStack, $this->httpKernel, $twig);
         $response = $modal->render('/background', 'modal.html.twig', ['key' => 'value']);
 
         $this->assertInstanceOf(Response::class, $response);
@@ -53,18 +55,20 @@ class ModalTest extends TestCase
         $request = new Request();
         $this->requestStack->push($request);
 
-        $this->twig->expects($this->once())
+        $twig = $this->createMock(Environment::class);
+        $twig->expects($this->once())
             ->method('render')
             ->with('modal.html.twig', [])
             ->willReturn('<div>Modal Content</div>');
 
         $expectedResponse = new Response('Background with modal');
 
-        $this->httpKernel->expects($this->once())
+        $httpKernel = $this->createMock(HttpKernelInterface::class);
+        $httpKernel->expects($this->once())
             ->method('handle')
             ->willReturn($expectedResponse);
 
-        $modal = new Modal($this->requestStack, $this->httpKernel, $this->twig);
+        $modal = new Modal($this->requestStack, $httpKernel, $twig);
         $response = $modal->render('/background', 'modal.html.twig');
 
         $this->assertSame($expectedResponse, $response);


### PR DESCRIPTION
## Contexte

Après un `composer update`, aucune dépréciation runtime n'était remontée (tests verts, PHPStan clean). Le seul point mort restant était **PHPUnit 9.6**, en fin de vie et incompatible à terme avec PHP 8.4.

## Changements

### ⬆️ Migration PHPUnit 9.6 → 12
- `phpunit/phpunit` bumpé en `^12.0`
- `phpunit.xml.dist` migré au schéma 12.x : `<source>`, `<extensions>`, `cacheDirectory`
- Remplacement du `SymfonyTestsListener` (supprimé) par `SymfonyExtension`
- Suppression de `convertDeprecationsToExceptions` (supprimé dès PHPUnit 10)
- `ModalTest` : stubs au lieu de mocks non configurés → plus aucune PHPUnit notice
- Normalisation des contraintes de version dans `composer.json`

### 👷 CI : test d'installation multi-Symfony
Nouveau job matrice qui vérifie l'installation et les tests sur :
- **Symfony 7.4** (PHP 8.3)
- **Symfony 8.1** (PHP 8.4)

via `symfony/flex` + `SYMFONY_REQUIRE`.

## Validation locale
- 246 tests, 676 assertions, **0 issue**
- PHPStan clean, php-cs-fixer clean
- Install testée sur Symfony 7.4.14 et 8.1.1 → OK dans les deux cas

## Note
Aucune release nécessaire : rien dans `src/` ne change, uniquement l'outillage de test et la CI.