### PR TITLE
✨ Add labelFormat and header options to LocaleSwitcher

### DIFF
--- a/docs/Navigation/localeSwitcher.md
+++ b/docs/Navigation/localeSwitcher.md
@@ -1,19 +1,44 @@
 ## Description
 
-A locale switcher dropdown for Bootstrap navbar.
+A locale switcher dropdown for Bootstrap navbar. Each entry shows the country flag — rounded, with a subtle border, and the locale's own-language name as `title` — optionally followed by a label.
+
+Flags render in a fixed 4:3 box (`1.5rem × 1.125rem`) with `preserveAspectRatio="xMidYMid slice"`, so they fill the box and the rounded corners hug the flag. The `cif:*` icons do not share one aspect ratio (`cif:nl` is 2:1, `cif:gb` is 3:2), and both the width and the height are set explicitly because a host application's `ux_icons.default_icon_attributes` would otherwise force them square.
 
 ## Parameters
 
-| Parameter          | Type    | Description                                     | Default        |
-|:-------------------|:--------|:------------------------------------------------|:---------------|
-| `locales`          | `array` | Available locales for the application           | `['fr', 'en']` |
-| `show_locale_name` | `bool`  | Whether to show the locale name in the switcher | `true`         |
+| Parameter         | Type      | Description                                                                                  | Default        |
+|:------------------|:----------|:---------------------------------------------------------------------------------------------|:---------------|
+| `locales`         | `array`   | Available locales for the application                                                        | `['en', 'fr']` |
+| `labelFormat`     | `string`  | Text next to the flag: `name` (Français), `code` (FR) or `none` (flag only)                   | `'name'`       |
+| `header`          | `?string` | Heading rendered at the top of the dropdown, e.g. `'Change language'`. Translate at the call site | `null`         |
+| `showLocaleName`  | `bool`    | **Deprecated** — use `labelFormat`. `false` still resolves `labelFormat` to `none`            | `true`         |
 
+`labelFormat` defaults to `name` unless `showLocaleName: false` was passed, in which case it resolves to `none`. An explicit `labelFormat` always wins over `showLocaleName`.
 
 ## Usage
 
 ```twig
 {{ component('Enabel:Ux:LocaleSwitcher') }}
+```
+
+### Compact switcher with a dropdown heading
+
+Flag plus uppercase locale code — keeps the navbar tight when the app runs three or more locales:
+
+```twig
+{{ component('Enabel:Ux:LocaleSwitcher', {
+    locales: enabled_locales,
+    labelFormat: 'code',
+    header: 'navigation.language.change'|trans,
+}) }}
+```
+
+Renders `🇬🇧 EN` in the navbar, and a dropdown headed *Change language* listing `🇫🇷 FR` and `🇳🇱 NL`.
+
+### Flag only
+
+```twig
+{{ component('Enabel:Ux:LocaleSwitcher', { labelFormat: 'none' }) }}
 ```
 
 ## Example in a Bootstrap navbar

--- a/src/Component/Navigation/LocaleSwitcher.php
+++ b/src/Component/Navigation/LocaleSwitcher.php
@@ -9,16 +9,37 @@
 
 namespace Enabel\Ux\Component\Navigation;
 
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\UX\TwigComponent\Attribute\PreMount;
 
 class LocaleSwitcher
 {
+    public const string LABEL_NAME = 'name';
+    public const string LABEL_CODE = 'code';
+    public const string LABEL_NONE = 'none';
+
     /**
      * @var array<string>
      */
     public array $locales;
+
+    /**
+     * @deprecated use {@see $labelFormat} instead; kept so existing call sites
+     *             passing `showLocaleName: false` keep rendering flags only
+     */
     public bool $showLocaleName;
+
+    /**
+     * One of `name` (English), `code` (EN) or `none` (flag only).
+     */
+    public string $labelFormat;
+
+    /**
+     * Optional heading rendered at the top of the dropdown, e.g. "Change
+     * language". Translate at the call site.
+     */
+    public ?string $header;
 
     /**
      * @param array<string, mixed> $data
@@ -37,9 +58,20 @@ class LocaleSwitcher
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setIgnoreUndefined();
-        $resolver->setDefaults(['locales' => ['en', 'fr'], 'showLocaleName' => true]);
+        $resolver->setDefaults([
+            'locales' => ['en', 'fr'],
+            'showLocaleName' => true,
+            // Derived so `showLocaleName: false` keeps meaning "flag only" for
+            // call sites written before labelFormat existed. An explicit
+            // labelFormat always wins.
+            'labelFormat' => static fn (Options $options): string => $options['showLocaleName'] ? self::LABEL_NAME : self::LABEL_NONE,
+            'header' => null,
+        ]);
 
         $resolver->setAllowedTypes('locales', ['array']);
         $resolver->setAllowedTypes('showLocaleName', 'bool');
+        $resolver->setAllowedTypes('labelFormat', 'string');
+        $resolver->setAllowedValues('labelFormat', [self::LABEL_NAME, self::LABEL_CODE, self::LABEL_NONE]);
+        $resolver->setAllowedTypes('header', ['string', 'null']);
     }
 }

--- a/templates/navigation/locale_switcher.html.twig
+++ b/templates/navigation/locale_switcher.html.twig
@@ -1,12 +1,17 @@
 {# Locale switcher component #}
+{% set flagClass = 'rounded border border-dark-subtle' %}
+{% set flagStyle = 'width: 1.5rem; height: 1.125rem; vertical-align: -0.15rem;' %}
 <li class="nav-item dropdown">
     {% set icon = (app.locale == 'en' ? 'gb' : app.locale) %}
     {% set locale_display_name = app.locale|locale_name(app.locale)|capitalize %}
     <a href="#" class="nav-link dropdown-toggle" id="dropdownLocales" data-bs-toggle="dropdown"
        aria-expanded="false">
-        <twig:ux:icon name="cif:{{ icon }}" style="width: 1.5rem; height: 1.5rem;" />{% if showLocaleName %}&nbsp;{{ locale_display_name }}{% endif %}
+        <twig:ux:icon name="cif:{{ icon }}" class="{{ flagClass }}" style="{{ flagStyle }}" preserveAspectRatio="xMidYMid slice" title="{{ locale_display_name }}" />{% if labelFormat == 'name' %}&nbsp;{{ locale_display_name }}{% elseif labelFormat == 'code' %}&nbsp;{{ app.locale|upper }}{% endif %}
     </a>
     <ul class="dropdown-menu" aria-labelledby="dropdownLocales">
+        {% if header %}
+            <li><h6 class="dropdown-header">{{ header }}</h6></li>
+        {% endif %}
         {% for locale in locales %}
             {% if locale != app.locale %}
             {% set icon = (locale == 'en' ? 'gb' : locale) %}
@@ -14,7 +19,7 @@
             {% set locale_display_name = locale|locale_name(locale)|capitalize %}
             <li role="menuitem">
                 <a class="dropdown-item" href="{{ navigation_url }}">
-                    <twig:ux:icon name="cif:{{ icon }}" style="width: 1.5rem; height: 1.5rem;" />{% if showLocaleName %}&nbsp;{{ locale_display_name }}{% endif %}
+                    <twig:ux:icon name="cif:{{ icon }}" class="{{ flagClass }}" style="{{ flagStyle }}" preserveAspectRatio="xMidYMid slice" title="{{ locale_display_name }}" />{% if labelFormat == 'name' %}&nbsp;{{ locale_display_name }}{% elseif labelFormat == 'code' %}&nbsp;{{ locale|upper }}{% endif %}
                 </a>
             </li>
             {% endif %}

--- a/tests/Component/Navigation/LocaleSwitcherTest.php
+++ b/tests/Component/Navigation/LocaleSwitcherTest.php
@@ -67,4 +67,63 @@ class LocaleSwitcherTest extends TestCase
         $component = new LocaleSwitcher();
         $component->preMount(['showLocaleName' => 'yes']);
     }
+
+    public function testLabelFormatDefaultsToName(): void
+    {
+        $component = new LocaleSwitcher();
+        $data = $component->preMount([]);
+
+        $this->assertSame(LocaleSwitcher::LABEL_NAME, $data['labelFormat']);
+    }
+
+    public function testLabelFormatCanBeSetToCode(): void
+    {
+        $component = new LocaleSwitcher();
+        $data = $component->preMount(['labelFormat' => LocaleSwitcher::LABEL_CODE]);
+
+        $this->assertSame('code', $data['labelFormat']);
+    }
+
+    public function testShowLocaleNameFalseStillMeansNoLabel(): void
+    {
+        $component = new LocaleSwitcher();
+        $data = $component->preMount(['showLocaleName' => false]);
+
+        $this->assertSame(LocaleSwitcher::LABEL_NONE, $data['labelFormat']);
+    }
+
+    public function testExplicitLabelFormatWinsOverShowLocaleName(): void
+    {
+        $component = new LocaleSwitcher();
+        $data = $component->preMount([
+            'showLocaleName' => false,
+            'labelFormat' => LocaleSwitcher::LABEL_CODE,
+        ]);
+
+        $this->assertSame(LocaleSwitcher::LABEL_CODE, $data['labelFormat']);
+    }
+
+    public function testComponentThrowsExceptionForUnknownLabelFormat(): void
+    {
+        $this->expectException(InvalidOptionsException::class);
+
+        $component = new LocaleSwitcher();
+        $component->preMount(['labelFormat' => 'initials']);
+    }
+
+    public function testHeaderDefaultsToNullAndCanBeSet(): void
+    {
+        $component = new LocaleSwitcher();
+
+        $this->assertNull($component->preMount([])['header']);
+        $this->assertSame('Change language', $component->preMount(['header' => 'Change language'])['header']);
+    }
+
+    public function testComponentThrowsExceptionForInvalidHeaderType(): void
+    {
+        $this->expectException(InvalidOptionsException::class);
+
+        $component = new LocaleSwitcher();
+        $component->preMount(['header' => 42]);
+    }
 }


### PR DESCRIPTION
## Problem

Apps carrying three or more locales cannot afford the full own-language name in the navbar — *English / Français / Nederlands* eats the space the menu items need — but the only alternative today, `showLocaleName: false`, leaves a bare flag with no textual cue at all.

So every app migrating off `enabel/layout-bundle` hand-rolls the same dropdown to get flag + short code + a "Change language" heading back. That is exactly what this component should provide.

There is also a rendering bug: flags were forced into a `1.5rem` **square**. The `cif:*` set has no single aspect ratio (`cif:nl` is 2:1, `cif:gb` is 3:2), so the flag was letterboxed inside its own box and the border framed empty space rather than the flag:

| Before | After |
|:--|:--|
| square box, flag shrunk and centred inside it | 4:3 box, flag fills it, rounding hugs the flag |

## Changes

- **`labelFormat`** — `name` (default, unchanged), `code` (EN) or `none` (flag only).
- **`header`** — optional `dropdown-header` at the top of the menu, e.g. `'Change language'`. Translate at the call site. Defaults to `null`, so nothing renders unless asked.
- Flags render rounded with a subtle border and carry the locale's own-language name as `title`, so `labelFormat: 'none'` stays accessible.
- Flags render in a fixed 4:3 box (`1.5rem × 1.125rem`) with `preserveAspectRatio="xMidYMid slice"`. **Both** width and height are explicit: a host application's `ux_icons.default_icon_attributes` (commonly `width/height: 1em`) otherwise wins and forces the square back — `width: auto` is not enough.

```twig
{{ component('Enabel:Ux:LocaleSwitcher', {
    locales: enabled_locales,
    labelFormat: 'code',
    header: 'navigation.language.change'|trans,
}) }}
```

Renders `🇬🇧 EN` in the navbar, and a dropdown headed *Change language* listing `🇫🇷 FR` and `🇳🇱 NL`.

## Backward compatibility

`showLocaleName` keeps working — `labelFormat` is *derived* from it, so a call site passing `false` still resolves to `none`. An explicit `labelFormat` always wins. The property is marked `@deprecated` rather than removed, and its existing tests still pass untouched.

The only visual change for callers who pass nothing is the flag styling (correct aspect ratio, rounded, bordered, `title`); the label still defaults to the own-language name.

## Verification

- `vendor/bin/phpunit` — **253 tests, 684 assertions, green** (7 new `LocaleSwitcher` tests covering the derivation, the precedence rule, and the rejected values).
- php-cs-fixer and phpstan clean.
- Rendered in a real Symfony 8 app across `/en`, `/fr` and `/nl`: verified the emitted DOM carries `title` per locale, the `rounded border border-dark-subtle` classes, hrefs `/fr` and `/nl`, the heading, and a 24×18 flag box.

## Drive-by

The docs documented the parameter as `show_locale_name`; the component has always read `showLocaleName`.
